### PR TITLE
Fix error when items are missing

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -290,7 +290,7 @@ function attachModuleSymbols(doclets, modules) {
 function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
     var nav = '';
 
-    if (items.length) {
+    if (items && items.length) {
         var itemsNav = '';
 
         items.forEach(function(item) {


### PR DESCRIPTION
My source code did not generate interface members for whatever reason, which caused the publish.js code to error. This fixes that scenario.
