### PR TITLE
Remove navigation bar when printing

### DIFF
--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -588,3 +588,14 @@ dl.param-type {
     margin-left: 0;
   }
 }
+
+@media only print {
+  nav {
+    display: none;
+  }
+
+  #main {
+    float: none;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
Adds a @media only print directive that hides the nav sidebar, making printouts and PDF more useful and readable.
