### PR TITLE
Set line height for headers to avoid line wraps overlapping

### DIFF
--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -42,6 +42,7 @@ h1, h2, h3, h4, h5, h6 {
   color: #000;
   font-weight: 400;
   margin: 0;
+  line-height: 1em;
 }
 
 h1 {


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/769877/15474159/11b8ba70-20f3-11e6-9f29-777aa3f7f413.png)
After:
![after](https://cloud.githubusercontent.com/assets/769877/15474158/1195e608-20f3-11e6-9456-d154b27d5ab6.png)
