### PR TITLE
Separate sizes on h2 and h3, for clarity

### DIFF
--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -56,12 +56,12 @@ h1.page-title {
 }
 
 h2 {
-  font-size: 24px;
+  font-size: 28px;
   margin: 1.5em 0 .3em;
 }
 
 h3 {
-  font-size: 24px;
+  font-size: 20px;
   margin: 1.2em 0 .3em;
 }
 


### PR DESCRIPTION
Feel free to reject if not to your taste; h2 and h3 headers had the same size so it was a bit confusing in my README's, so I changed the font-size values a bit.
