### PR TITLE
Add showInheritedInNav configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ In your `.jsdoc.json` file, add a template option.
     "templates": {
         "cleverLinks": false,
         "monospaceLinks": true,
-        "useLongnameInNav": false
+        "useLongnameInNav": false,
+        "showInheritedInNav": true
     },
     "opts": {
         "destination": "./docs/",

--- a/publish.js
+++ b/publish.js
@@ -322,6 +322,10 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
                     itemsNav += "<ul class='methods'>";
 
                     methods.forEach(function (method) {
+                        if (method.inherited && conf.showInheritedInNav === false) {
+                            return
+                        }
+
                         itemsNav += "<li data-type='method'>";
                         itemsNav += linkto(method.longname, method.name);
                         itemsNav += "</li>";


### PR DESCRIPTION
This allows one to hide inherited methods from the left navigation, making projects that heavily use inheritance considerably easier to navigate.