### PR TITLE
Can show whole tutorial tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ In your `.jsdoc.json` file, add a template option.
         "cleverLinks": false,
         "monospaceLinks": true,
         "useLongnameInNav": false,
-        "showInheritedInNav": true
+        "showInheritedInNav": true,
+        "showTutorialChildren": true
     },
     "opts": {
         "destination": "./docs/",

--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -262,6 +262,11 @@ nav li {
   font-size: 13px;
 }
 
+.nav-tut-list {
+  margin: 0 0.5em;
+  padding: 0;
+}
+
 .type-function {
   background: #B3E5FC;
   color: #0288D1;


### PR DESCRIPTION
This allows children tutorial links to show up in the nav under their parents in order.

The `showTutorialChildren` option lets you turn off this feature.