### PR TITLE
copyFileSync issue fix for node 8.4.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Minami
 
+# DEPRECATED! MODIFICATIONS ARE NOT SUPPORTED IN NODE 10, USE ORIGINAL MINAMI THEME.
+
 A clean, responsive documentation template theme for JSDoc 3.
 
 ![Minami Screenshot](http://i.imgur.com/rPCIFqT.png)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "minami",
-  "version": "1.2.3",
+  "name": "minami-compat",
+  "version": "1.2.4",
   "description": "Clean and minimal JSDoc 3 Template / Theme",
   "main": "publish.js",
   "scripts": {

--- a/publish.js
+++ b/publish.js
@@ -594,7 +594,7 @@ exports.publish = function(taffyData, opts, tutorials) {
   staticFiles.forEach(function(fileName) {
     var toDir = fs.toDir(fileName.replace(fromDir, outdir))
     fs.mkPath(toDir)
-    fs.copyFileSync(fileName, toDir)
+    fs.copyFileSync(fileName, path.resolve(toDir, path.basename(fileName)))
   })
 
   // copy user-specified static files to outdir


### PR DESCRIPTION
Fix for `Error: EISDIR: illegal operation on a directory, copyfile '/Users/xxx/yyy/node_modules/minami/static/fonts/OpenSans-Bold-webfont.eot' -> '/Users/xxx/yyy/jsdoc/fonts'` in node 8.4.0+ versions. 
