### PR TITLE
Add support for @modifies, @yields, @hideconstructor, and @namespace

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -67,6 +67,16 @@ function needsSignature(doclet) {
         break
       }
     }
+  } else if (
+    doclet.kind === 'namespace' &&
+    doclet.meta &&
+    doclet.meta.code &&
+    doclet.meta.code.type &&
+    doclet.meta.code.type.match(/[Ff]unction/)
+  ) {
+    // and namespaces that are functions get a signature (but finding them is a
+    // bit messy)
+    needsSig = true
   }
 
   return needsSig
@@ -157,12 +167,13 @@ function addSignatureReturns(f) {
   var attribsString = ""
   var returnTypes = []
   var returnTypesString = ""
+  var source = f.yields || f.returns
 
   // jam all the return-type attributes into an array. this could create odd results (for example,
   // if there are both nullable and non-nullable return types), but let's assume that most people
   // who use multiple @return tags aren't using Closure Compiler type annotations, and vice-versa.
-  if (f.returns) {
-    f.returns.forEach(function(item) {
+  if (source) {
+    source.forEach(function(item) {
       helper.getAttribs(item).forEach(function(attrib) {
         if (attribs.indexOf(attrib) === -1) {
           attribs.push(attrib)
@@ -173,8 +184,8 @@ function addSignatureReturns(f) {
     attribsString = buildAttribsString(attribs)
   }
 
-  if (f.returns) {
-    returnTypes = addNonParamAttributes(f.returns)
+  if (source) {
+    returnTypes = addNonParamAttributes(source)
   }
   if (returnTypes.length) {
     returnTypesString = util.format(

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -3,20 +3,22 @@ var data = obj;
 var self = this;
 ?>
 <div class="section-method">
-<?js if (data.kind !== 'module') { ?>
+<?js if (data.kind !== 'module' && !data.hideconstructor) { ?>
     <?js if (data.kind === 'class' && data.classdesc) { ?>
     <h2>Constructor</h2>
     <?js } ?>
 
+    <?js if (data.kind !== 'namespace') { ?>
     <h4 class="name" id="<?js= id ?>"><?js= data.attribs + (kind === 'class' ? 'new ' : '') +
     name + (data.signature || '') ?></h4>
+    <?js } ?>
 
     <?js if (data.summary) { ?>
     <p class="summary"><?js= summary ?></p>
     <?js } ?>
 <?js } ?>
 
-<?js if (data.kind !== 'module' && data.description) { ?>
+<?js if (data.kind !== 'module' && data.description && !data.hideconstructor) { ?>
 <div class="description">
     <?js= data.description ?>
 </div>
@@ -45,7 +47,7 @@ var self = this;
     <ul><li><?js= this.linkto(data['this'], data['this']) ?></li></ul>
 <?js } ?>
 
-<?js if (data.params && params.length) { ?>
+<?js if (data.params && params.length && !data.hideconstructor) { ?>
     <h5>Parameters:</h5>
     <?js= this.partial('params.tmpl', params) ?>
 <?js } ?>
@@ -80,6 +82,20 @@ var self = this;
 </div>
 <?js } ?>
 
+<?js if (data.modifies && modifies.length) { ?>
+<div class="section-modifies">
+<h5>Modifies:</h5>
+<?js if (modifies.length > 1) { ?><ul><?js
+    modifies.forEach(function(r) { ?>
+        <li><?js= self.partial('modifies.tmpl', r) ?></li>
+    <?js });
+?></ul><?js } else {
+    modifies.forEach(function(r) { ?>
+        <?js= self.partial('modifies.tmpl', r) ?>
+    <?js }); } ?>
+</div>
+<?js } ?>
+
 <?js if (data.exceptions && exceptions.length) { ?>
 <div class="section-throws">
 <h5>Throws:</h5>
@@ -104,6 +120,20 @@ var self = this;
 ?></ul><?js } else {
     returns.forEach(function(r) { ?>
         <?js= self.partial('returns.tmpl', r) ?>
+    <?js }); } ?>
+</div>
+<?js } ?>
+
+<?js if (data.yields && yields.length) { ?>
+<div class="section-yields">
+<h5>Yields:</h5>
+<?js if (yields.length > 1) { ?><ul><?js
+    yields.forEach(function(r) { ?>
+        <li><?js= self.partial('yields.tmpl', r) ?></li>
+    <?js });
+?></ul><?js } else {
+    yields.forEach(function(r) { ?>
+        <?js= self.partial('yields.tmpl', r) ?>
     <?js }); } ?>
 </div>
 <?js } ?>

--- a/tmpl/modifies.tmpl
+++ b/tmpl/modifies.tmpl
@@ -1,0 +1,14 @@
+<?js
+var data = obj || {};
+?>
+
+<?js if (data.type && data.type.names) {?>
+<dl>
+    <dt>
+        Type
+    </dt>
+    <dd>
+        <?js= this.partial('type.tmpl', data.type.names) ?>
+    </dd>
+</dl>
+<?js } ?>


### PR DESCRIPTION
Add support for `@modifies`, `@yields`, `@hideconstructor`, and `@namespace`.

I basically copied some code from the [default template](https://github.com/jsdoc/jsdoc/blob/9f28c6c2ddb297f11f8235628f5a1b5b1bd36345/templates/default/tmpl/method.tmpl) but changed it slightly for Minami.